### PR TITLE
feat: Whitelist and blacklist to increase the fuzzy matching function

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -33,12 +33,18 @@ function filterAPI (apis) {
 
     api.mocks = api.mocks.filter((mock) => {
       if (!_.isEmpty(whiteList)) {
-        return _.includes(whiteList, mock.url)
+        return _.includes(revertUrl(whiteList, mock.url), mock.url)
       } else if (!_.isEmpty(blackList)) {
-        return !_.includes(blackList, mock.url)
+        return !_.includes(revertUrl(blackList, mock.url), mock.url)
       }
       return true
     })
+  })
+}
+
+function revertUrl (filters, url) {
+  return filters.map(filter => {
+    return url.indexOf(filter) !== -1 ? url : filter
   })
 }
 


### PR DESCRIPTION
Whitelist and blacklist to increase the fuzzy matching function. (Sometimes the interface may be similar,And we can not write one by one)
just like:
```js
{
  white: ['/demo/user']
}
```